### PR TITLE
feat: Implement Readability and Correctness button functionalities

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -134,6 +134,32 @@ function App() {
     setOutput(aiResponse);
   };
 
+  // Readability
+  const handleReadability = async () => {
+    if (!transcript.trim()) {
+      setOutput("Please enter some text before assessing readability.");
+      return;
+    }
+    setOutput('Calculating readability...');
+    // Simulate API call
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    const readabilityResponse = "Readability Score: Good";
+    setOutput(readabilityResponse);
+  };
+
+  // Correctness
+  const handleCorrectness = async () => {
+    if (!transcript.trim()) {
+      setOutput("Please enter some text before checking correctness.");
+      return;
+    }
+    setOutput('Checking correctness...');
+    // Simulate API call
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    const correctnessResponse = "No correctness issues found.";
+    setOutput(correctnessResponse);
+  };
+
   return (
     <div style={{
       minHeight: '100vh',
@@ -238,7 +264,7 @@ function App() {
         </div>
         <div style={{ display: 'flex', gap: 16, marginBottom: 18 }}>
           <button
-            onClick={() => handleEval('Readability')}
+            onClick={handleReadability}
             style={{
               background: '#e6f2fb',
               color: '#223',
@@ -252,7 +278,7 @@ function App() {
             }}
           >Readability</button>
           <button
-            onClick={() => handleEval('Correctness')}
+            onClick={handleCorrectness}
             style={{
               background: '#e6f2fb',
               color: '#223',

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -39,4 +39,68 @@ describe('App component', () => {
       });
     });
   });
+
+  describe('Correctness functionality', () => {
+    test('displays error message when transcript is empty', () => {
+      render(<App />);
+      const correctnessButton = screen.getByText('Correctness');
+      fireEvent.click(correctnessButton);
+      const textareas = screen.getAllByRole('textbox');
+      const outputTextarea = textareas[1];
+      expect(outputTextarea.value).toBe('Please enter some text before checking correctness.');
+    });
+
+    test('displays Correctness response when transcript is not empty', async () => {
+      render(<App />);
+      const correctnessButton = screen.getByText('Correctness');
+      const textareas = screen.getAllByRole('textbox');
+      const transcriptTextarea = textareas[0];
+      const outputTextarea = textareas[1];
+
+      // Simulate user typing into the transcript textarea
+      fireEvent.change(transcriptTextarea, { target: { value: 'This is a test transcript for correctness.' } });
+      
+      fireEvent.click(correctnessButton);
+
+      // Advance timers to resolve the promise in handleCorrectness
+      jest.advanceTimersByTime(1000);
+
+      // Wait for the output to update with the Correctness response
+      await waitFor(() => {
+        expect(outputTextarea.value).toBe('No correctness issues found.');
+      });
+    });
+  });
+
+  describe('Readability functionality', () => {
+    test('displays error message when transcript is empty', () => {
+      render(<App />);
+      const readabilityButton = screen.getByText('Readability');
+      fireEvent.click(readabilityButton);
+      const textareas = screen.getAllByRole('textbox');
+      const outputTextarea = textareas[1];
+      expect(outputTextarea.value).toBe('Please enter some text before assessing readability.');
+    });
+
+    test('displays Readability response when transcript is not empty', async () => {
+      render(<App />);
+      const readabilityButton = screen.getByText('Readability');
+      const textareas = screen.getAllByRole('textbox');
+      const transcriptTextarea = textareas[0];
+      const outputTextarea = textareas[1];
+
+      // Simulate user typing into the transcript textarea
+      fireEvent.change(transcriptTextarea, { target: { value: 'This is a test transcript for readability.' } });
+      
+      fireEvent.click(readabilityButton);
+
+      // Advance timers to resolve the promise in handleReadability
+      jest.advanceTimersByTime(1000);
+
+      // Wait for the output to update with the Readability response
+      await waitFor(() => {
+        expect(outputTextarea.value).toBe('Readability Score: Good');
+      });
+    });
+  });
 });


### PR DESCRIPTION
This commit introduces the following features:

1.  **Readability Button:**
    *   I've added a `handleReadability` function to `src/App.js`.
    *   This function simulates an API call for readability assessment.
    *   It will display a message if the transcript is empty.
    *   I've updated the "Readability" button to use this handler.
    *   I've also added unit tests in `src/App.test.js` for empty and non-empty transcript scenarios.

2.  **Correctness Button:**
    *   I've added a `handleCorrectness` function to `src/App.js`.
    *   This function simulates an API call for correctness checking.
    *   It will display a message if the transcript is empty.
    *   I've updated the "Correctness" button to use this handler.
    *   I've also added unit tests in `src/App.test.js` for empty and non-empty transcript scenarios.

Both features currently use mocked API responses with a 1-second delay.